### PR TITLE
Implement basic Salesforce bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Salesforce Bot
+
+This project provides a simple command line bot that demonstrates how chat inputs
+could be mapped to Salesforce updates. It resolves user-provided field names to
+Salesforce API field names, logs all actions, and includes a minimal self-learning
+component for correcting field mappings.
+
+## Usage
+
+Run the bot with Python:
+
+```bash
+python -m salesforce_bot.bot
+```
+
+Enter commands in the format:
+
+```
+<loan_id> <field name> <value>
+```
+
+For example:
+
+```
+12345 "loan amount" 100000
+```
+
+This will attempt to update the `Loan_Amount__c` field for loan `12345` to `100000`.
+
+All updates are logged to `salesforce_bot.log`.

--- a/salesforce_bot/__init__.py
+++ b/salesforce_bot/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['bot', 'salesforce_api', 'field_mapping', 'learning']

--- a/salesforce_bot/bot.py
+++ b/salesforce_bot/bot.py
@@ -1,0 +1,65 @@
+import difflib
+from dataclasses import dataclass
+from typing import Optional
+
+from .field_mapping import FIELD_MAPPING
+from .logging_config import logger
+from .salesforce_api import SalesforceAPI
+from .learning import MappingLearner
+
+@dataclass
+class UpdateRequest:
+    record_id: str
+    field: str
+    value: str
+
+class SalesforceBot:
+    def __init__(self):
+        self.api = SalesforceAPI()
+        self.learner = MappingLearner()
+
+    def resolve_field(self, user_field: str) -> Optional[str]:
+        """Resolve a user-provided field name to a Salesforce API field name."""
+        corrected = self.learner.get_corrected_field(user_field)
+        if corrected:
+            return corrected
+        candidates = FIELD_MAPPING.keys()
+        matches = difflib.get_close_matches(user_field.lower(), candidates, n=1, cutoff=0.6)
+        if matches:
+            field = FIELD_MAPPING[matches[0]]
+            logger.info("Resolved field '%s' -> '%s'", user_field, field)
+            return field
+        logger.warning("Could not resolve field: %s", user_field)
+        return None
+
+    def handle_update(self, req: UpdateRequest) -> bool:
+        field_api_name = self.resolve_field(req.field)
+        if not field_api_name:
+            logger.error("Unknown field: %s", req.field)
+            return False
+        logger.info("Updating record %s field %s with value %s", req.record_id, field_api_name, req.value)
+        return self.api.update_record('Loan__c', req.record_id, field_api_name, req.value)
+
+
+def main():
+    bot = SalesforceBot()
+    print("Enter commands in the format: <loan_id> <field> <value>")
+    print("Type 'quit' to exit")
+    while True:
+        raw = input('> ').strip()
+        if raw.lower() in {'q', 'quit', 'exit'}:
+            break
+        parts = raw.split(maxsplit=2)
+        if len(parts) != 3:
+            print("Invalid input. Expected: <loan_id> <field> <value>")
+            continue
+        loan_id, field, value = parts
+        req = UpdateRequest(record_id=loan_id, field=field, value=value)
+        success = bot.handle_update(req)
+        if success:
+            print("Update successful")
+        else:
+            print("Update failed")
+
+if __name__ == '__main__':
+    main()

--- a/salesforce_bot/field_mapping.py
+++ b/salesforce_bot/field_mapping.py
@@ -1,0 +1,9 @@
+from typing import Dict
+
+# Example mapping from human-readable field names to Salesforce API field names
+FIELD_MAPPING: Dict[str, str] = {
+    "loan amount": "Loan_Amount__c",
+    "interest rate": "Interest_Rate__c",
+    "closing date": "Closing_Date__c",
+    # Add more mappings as needed
+}

--- a/salesforce_bot/learning.py
+++ b/salesforce_bot/learning.py
@@ -1,0 +1,15 @@
+from typing import Dict
+from .logging_config import logger
+
+class MappingLearner:
+    """Simple learner that stores user corrections to improve field mapping."""
+
+    def __init__(self):
+        self.corrections: Dict[str, str] = {}
+
+    def record_correction(self, user_input: str, correct_field: str):
+        logger.info("Recording correction: '%s' -> '%s'", user_input, correct_field)
+        self.corrections[user_input.lower()] = correct_field
+
+    def get_corrected_field(self, user_input: str) -> str:
+        return self.corrections.get(user_input.lower())

--- a/salesforce_bot/logging_config.py
+++ b/salesforce_bot/logging_config.py
@@ -1,0 +1,14 @@
+import logging
+
+LOG_FILE = 'salesforce_bot.log'
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger('salesforce_bot')

--- a/salesforce_bot/salesforce_api.py
+++ b/salesforce_bot/salesforce_api.py
@@ -1,0 +1,15 @@
+class SalesforceAPI:
+    """A stub Salesforce API client."""
+
+    def __init__(self):
+        # Placeholder for authentication initialization
+        pass
+
+    def update_record(self, object_name: str, record_id: str, field: str, value):
+        """Update a field on a Salesforce record.
+
+        In a real implementation this would make a REST API call.
+        """
+        print(f"[SalesforceAPI] Would update {object_name} {record_id}: {field}={value}")
+        # return success status
+        return True


### PR DESCRIPTION
## Summary
- add a minimal command line Salesforce bot
- stub out a Salesforce API client
- provide simple field mapping data and self-learning module
- configure logging
- document usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684205aed9f8832f8248fc12732798eb